### PR TITLE
fix: fix CI release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,12 +31,8 @@ jobs:
         run: |
           zip -r h5p-standalone-release.zip dist/ README.md
 
-      # - name: Release
-      #   uses: cycjimmy/semantic-release-action@v3
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-      #   with:
-      #     extra_plugins: |
-      #       @semantic-release/changelog
-      #       @semantic-release/git
+      - name: Release
+        uses: actions/upload-artifact@v4
+        with:
+          name: h5p-standalone-release
+          path: h5p-standalone-release.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version:  14
+          node-version:  22
           cache: 'yarn'
 
       - name: Install dependencies
@@ -31,12 +31,12 @@ jobs:
         run: |
           zip -r h5p-standalone-release.zip dist/ README.md
 
-      - name: Release
-        uses: cycjimmy/semantic-release-action@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-        with:
-          extra_plugins: |
-            @semantic-release/changelog
-            @semantic-release/git
+      # - name: Release
+      #   uses: cycjimmy/semantic-release-action@v3
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+      #   with:
+      #     extra_plugins: |
+      #       @semantic-release/changelog
+      #       @semantic-release/git


### PR DESCRIPTION
### What does this PR do?

It fixes the CI release action: updates node to version 22 in CI and comments out the job related to npm publishing, since for now we do not intend to do that!